### PR TITLE
.NETを2.1からFrameworkに変更（SerialPortを使用するために）

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -915,7 +915,7 @@ PlayerSettings:
   gcIncremental: 1
   gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform: {}
-  editorAssembliesCompatibilityLevel: 1
+  editorAssembliesCompatibilityLevel: 2
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: cut-and-recover
@@ -993,7 +993,7 @@ PlayerSettings:
   hmiCpuConfiguration: 
   hmiLogStartupTiming: 0
   qnxGraphicConfPath: 
-  apiCompatibilityLevel: 6
+  apiCompatibilityLevel: 3
   captureStartupLogs: {}
   activeInputHandler: 1
   windowsGamepadBackendHint: 0


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## やったこと
.NETのAPIを2.1からFrameworkに変更した
2.1だとシリアルポートをサポートしてなくてコンパイルエラーでる
<img width="2027" height="986" alt="image" src="https://github.com/user-attachments/assets/620b3c9f-e940-4f92-9279-657ac05a9e48" />

## 関連Issue
なし

## PR作成時のルール
- Reviewersにryotan1ffかYugo0716を設定
- Assigneesに自分を設定
- 「やったこと」と「関連Issue」を書き込み

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
<!-- for GitHub Copilot review rule -->
[must] → かならず変更してね  
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
[nits] → ささいな指摘(nitpick)
[ask] → 質問  
[fyi] → 参考情報(for your information)
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->