### PR TITLE
手がほほくっつきモードのときの位置ずれを直した

### DIFF
--- a/Assets/Scenes/Tentative-CutScene.unity
+++ b/Assets/Scenes/Tentative-CutScene.unity
@@ -1539,12 +1539,6 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: -320645280802139608, guid: 4c41e7864b6592244886800333fe433c, type: 3}
       insertIndex: -1
       addedObject: {fileID: 360426831}
-    - targetCorrespondingSourceObject: {fileID: -320645280802139608, guid: 4c41e7864b6592244886800333fe433c, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1708974554}
-    - targetCorrespondingSourceObject: {fileID: -320645280802139608, guid: 4c41e7864b6592244886800333fe433c, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 503431664}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 4c41e7864b6592244886800333fe433c, type: 3}
       insertIndex: -1
@@ -3328,12 +3322,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 503431663}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.005808997, y: -0.9884562, z: 0.15053657, w: -0.0161052}
-  m_LocalPosition: {x: -0.007845955, y: -1.5192053, z: 0.22422974}
-  m_LocalScale: {x: 1.1111547, y: 1.1265658, z: 1.5813291}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.3, y: 0, z: 0.2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 774592384}
+  m_Father: {fileID: 1931851594}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &523531912
 PrefabInstance:
@@ -6013,7 +6007,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7993765477841990357, guid: b7f4153afee46bb4ab930b22a4caf471, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.105
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9192623165065142701, guid: b7f4153afee46bb4ab930b22a4caf471, type: 3}
       propertyPath: m_LocalScale.y
@@ -6033,6 +6027,12 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 7993765477841990357, guid: b7f4153afee46bb4ab930b22a4caf471, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1229822987}
+    - targetCorrespondingSourceObject: {fileID: 7993765477841990357, guid: b7f4153afee46bb4ab930b22a4caf471, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1708974554}
+    - targetCorrespondingSourceObject: {fileID: 7993765477841990357, guid: b7f4153afee46bb4ab930b22a4caf471, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 503431664}
     - targetCorrespondingSourceObject: {fileID: 7993765477841908485, guid: b7f4153afee46bb4ab930b22a4caf471, type: 3}
       insertIndex: -1
       addedObject: {fileID: 485361407}
@@ -6277,7 +6277,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 831842289}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 00f7b4f30efc160479cffd37f81d4e84, type: 3}
   m_Name: 
@@ -12465,12 +12465,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1708974553}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.005808997, y: -0.9884562, z: 0.15053657, w: -0.0161052}
-  m_LocalPosition: {x: -0.007845955, y: -1.5192053, z: 0.22422974}
-  m_LocalScale: {x: 1.1111547, y: 1.1265658, z: 1.5813291}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.3, y: 0, z: 0.2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 774592384}
+  m_Father: {fileID: 1931851594}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1738239559
 PrefabInstance:


### PR DESCRIPTION
RHandMoveはバグあるっぽいから不使用にした

<!-- I want to review in Japanese. -->
## やったこと

Aキーを押して（戻りフェーズを想定）手がほほにくっつくモードのとき，位置ずれがある問題を修正
今は斬られ度合に関係なく，手は頭の中心を親に固定されているけど見栄えギリ大丈夫なはず

## 関連Issue

- close #60

## PR作成時のルール
- Reviewersにryotan1ffかYugo0716を設定
- Assigneesに自分を設定
- 「やったこと」と「関連Issue」を書き込み

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
<!-- for GitHub Copilot review rule -->
[must] → かならず変更してね  
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)  
[nits] → ささいな指摘(nitpick)
[ask] → 質問  
[fyi] → 参考情報(for your information)
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->